### PR TITLE
Fix app.json logo

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "name": "Punchcard Demo",
   "description": "Demo deployable instance of the Punchcard CMS",
   "repository": "https://github.com/punchcard-cms/demo",
-  "logo": "https://punchcard-cms.herokuapp.com/images/punchcard-image.svg",
+  "logo": "https://cloud.githubusercontent.com/assets/377188/20324120/4ae50c9c-ab4d-11e6-836a-f7a6455f99ab.png",
   "keywords": [
     "node",
     "express",


### PR DESCRIPTION
Logo doesn't work because deploying directly to Heroku is weird. Use this PNG for the meantime

---
`DCO 1.1 Signed-off-by: Sam Richard <sam@snug.ug>`

